### PR TITLE
Dinero objects can not be pickled

### DIFF
--- a/dinero/base.py
+++ b/dinero/base.py
@@ -1,0 +1,11 @@
+class DineroObject(object):
+    def __getattr__(self, attr):
+        if attr == '__setstate__':
+            raise AttributeError
+        try:
+            return self.data[attr]
+        except KeyError as e:
+            raise AttributeError(e)
+
+    def to_dict(self):
+        return vars(self)

--- a/dinero/card.py
+++ b/dinero/card.py
@@ -1,6 +1,7 @@
 from dinero.log import log
+from dinero.base import DineroObject
 
-class CreditCard(object):
+class CreditCard(DineroObject):
     """
     A Customer resource. `Customer.create` uses the gateway to create a
     customer.  You can use this Customer object in calls to
@@ -10,6 +11,7 @@ class CreditCard(object):
     def __init__(self, customer_id, **kwargs):
         self.customer_id = customer_id
         self.data = kwargs
+
     @log
     def save(self):
         raise NotImplemented
@@ -18,23 +20,11 @@ class CreditCard(object):
     def delete(self):
         raise NotImplemented
 
-    def to_dict(self):
-        return vars(self)
-
-    def __getattr__(self, attr):
-        if attr == '__setstate__':
-            raise AttributeError
-        try:
-            return self.data[attr]
-        except KeyError as e:
-            raise AttributeError(e)
-
     def __setattr__(self, attr, val):
         if attr in ['customer_id', 'data']:
             self.__dict__[attr] = val
         else:
             self.data[attr] = val
-
 
     @classmethod
     def from_dict(cls, dict):

--- a/dinero/customer.py
+++ b/dinero/customer.py
@@ -2,9 +2,10 @@ from dinero import get_gateway
 from dinero.exceptions import InvalidCustomerException
 from dinero.log import log
 from dinero.card import CreditCard
+from dinero.base import DineroObject
 
 
-class Customer(object):
+class Customer(DineroObject):
     """
     A Customer resource. `Customer.create` uses the gateway to create a
     customer.  You can use this Customer object in calls to
@@ -59,17 +60,6 @@ class Customer(object):
         gateway = get_gateway(gateway_name)
         resp = gateway.add_card_to_customer(self, options)
         return CreditCard(customer=self, **resp)
-
-    def to_dict(self):
-        return vars(self)
-
-    def __getattr__(self, attr):
-        if attr == '__setstate__':
-            raise AttributeError
-        try:
-            return self.data[attr]
-        except KeyError as e:
-            raise AttributeError(e)
 
     def __setattr__(self, attr, val):
         if attr in ['gateway_name', 'customer_id', 'data']:

--- a/dinero/transaction.py
+++ b/dinero/transaction.py
@@ -1,8 +1,9 @@
 from dinero import exceptions, get_gateway
 from dinero.log import log
+from dinero.base import DineroObject
 
 
-class Transaction(object):
+class Transaction(DineroObject):
     """
     A Transaction resource. `Transaction.create` uses the gateway to charge a
     card, and returns an object for future manipulations of the transaction,
@@ -46,18 +47,6 @@ class Transaction(object):
     def settle(self, amount=None):
         gateway = get_gateway(self.gateway_name)
         return gateway.settle(self, amount or self.price)
-
-
-    def to_dict(self):
-        return vars(self)
-
-    def __getattr__(self, attr):
-        if attr == '__setstate__':
-            raise AttributeError
-        try:
-            return self.data[attr]
-        except KeyError as e:
-            raise AttributeError(e)
 
     def __setattr__(self, attr, val):
         if attr in ['gateway_name', 'transaction_id', 'price', 'data']:


### PR DESCRIPTION
When pickle tries to restore a dinero object, it tries to get its `__setstate__` method. This calls `__getattr__`  on the dinero object, which tries to access `self.data`, which doesn't exist yet. This results in  `__getattr__` calling itself over and over again.

Here's my solution. I don't like it.
