### PR TITLE
use a DineroException instead of plain Exception for unknown response

### DIFF
--- a/dinero/gateways/authorizenet_gateway.py
+++ b/dinero/gateways/authorizenet_gateway.py
@@ -183,7 +183,7 @@ def payment_exception_factory(errors):
             # instantiate all the classes in RESPONSE_CODE_EXCEPTION_MAP[code]
             exceptions.extend(exception_class(message) for exception_class in RESPONSE_CODE_EXCEPTION_MAP[code])
         except KeyError:
-            raise Exception("I don't recognize this error: {0!r}. Better call the programmers.".format(errors))
+            raise DineroException("I don't recognize this error: {0!r}. Better call the programmers.".format(errors))
     return exceptions
 
 


### PR DESCRIPTION
An unknown response from authorize.net probably counts as a DineroException, so generic exception handling code can treat it as a generic card-declined error.
