### PR TITLE
Have add_card signature match the doc

### DIFF
--- a/dinero/customer.py
+++ b/dinero/customer.py
@@ -87,7 +87,7 @@ class Customer(DineroObject):
         return True
 
     @log
-    def add_card(self, options, gateway_name=None):
+    def add_card(self, gateway_name=None, **options):
         """
         The first credit card is added when you call :meth:`create`, but you
         can add more cards using this method. ::


### PR DESCRIPTION
The doc specify:

```
customer.add_card(
    number='4222222222222',
    cvv='900',
   month='12'
   year='2015'
   address='123 Elm St',
   zip='12345',
)
```

This fix makes the API match the doc. But it is not backward compatible. I assumed no dinero user was using this feature.

No?
